### PR TITLE
Fix broken links on alternatives index page

### DIFF
--- a/alternatives/index.html
+++ b/alternatives/index.html
@@ -212,7 +212,7 @@
                 <div class="card__number" aria-hidden="true">01</div>
                 <div>
                     <p class="card__category">Brutalist</p>
-                    <h2 class="card__name"><a href="brutalist.html">Brutalist</a></h2>
+                    <h2 class="card__name"><a href="/alternatives/brutalist.html">Brutalist</a></h2>
                     <p class="card__desc">
                         Aggressive oversized typography, stark black/off-white contrast, exposed grid lines,
                         harsh 2px borders, rotated section labels. Bebas Neue + Space Mono. Raw red accent.
@@ -223,7 +223,7 @@
                         <li>Aggressive</li>
                         <li>Grid</li>
                     </ul>
-                    <a href="brutalist.html" class="card__link">View Design &rarr;</a>
+                    <a href="/alternatives/brutalist.html" class="card__link">View Design &rarr;</a>
                 </div>
             </article>
 
@@ -231,7 +231,7 @@
                 <div class="card__number" aria-hidden="true">02</div>
                 <div>
                     <p class="card__category">Editorial</p>
-                    <h2 class="card__name"><a href="editorial.html">Editorial</a></h2>
+                    <h2 class="card__name"><a href="/alternatives/editorial.html">Editorial</a></h2>
                     <p class="card__desc">
                         Premium magazine feature article layout. Cormorant Garamond + Crimson Pro.
                         Drop caps, pull quotes, multi-column text, warm cream/ink dark palette with muted gold accents.
@@ -242,7 +242,7 @@
                         <li>Magazine</li>
                         <li>Elegant</li>
                     </ul>
-                    <a href="editorial.html" class="card__link">View Design &rarr;</a>
+                    <a href="/alternatives/editorial.html" class="card__link">View Design &rarr;</a>
                 </div>
             </article>
 
@@ -250,7 +250,7 @@
                 <div class="card__number" aria-hidden="true">03</div>
                 <div>
                     <p class="card__category">Editorial &mdash; Literary</p>
-                    <h2 class="card__name"><a href="literary.html">Literary</a></h2>
+                    <h2 class="card__name"><a href="/alternatives/literary.html">Literary</a></h2>
                     <p class="card__desc">
                         Chapbook / book design. EB Garamond with chapter numbers, drop caps, footnotes,
                         margin notes, running headers, ornamental dividers. Warm umber/parchment palette.
@@ -261,7 +261,7 @@
                         <li>Serif</li>
                         <li>Warm</li>
                     </ul>
-                    <a href="literary.html" class="card__link">View Design &rarr;</a>
+                    <a href="/alternatives/literary.html" class="card__link">View Design &rarr;</a>
                 </div>
             </article>
 
@@ -269,7 +269,7 @@
                 <div class="card__number" aria-hidden="true">04</div>
                 <div>
                     <p class="card__category">Editorial &mdash; Art Catalog</p>
-                    <h2 class="card__name"><a href="art-catalog.html">Art Catalog</a></h2>
+                    <h2 class="card__name"><a href="/alternatives/art-catalog.html">Art Catalog</a></h2>
                     <p class="card__desc">
                         Gallery exhibition catalog. Numbered plates, object labels, table of contents with
                         dotted leaders, catalogue raisonn&eacute;. Hanken Grotesk. Cool institutional palette.
@@ -280,7 +280,7 @@
                         <li>Clinical</li>
                         <li>Sans-serif</li>
                     </ul>
-                    <a href="art-catalog.html" class="card__link">View Design &rarr;</a>
+                    <a href="/alternatives/art-catalog.html" class="card__link">View Design &rarr;</a>
                 </div>
             </article>
 
@@ -288,7 +288,7 @@
                 <div class="card__number" aria-hidden="true">05</div>
                 <div>
                     <p class="card__category">Brutalist &mdash; Cyberpunk</p>
-                    <h2 class="card__name"><a href="neon-noir.html">Neon Noir</a></h2>
+                    <h2 class="card__name"><a href="/alternatives/neon-noir.html">Neon Noir</a></h2>
                     <p class="card__desc">
                         Blade Runner neon noir. CSS rain, scanlines, phosphor neon glow effects,
                         fog gradients. Rajdhani + Share Tech Mono. Pink/cyan neon on blue-black.
@@ -299,7 +299,7 @@
                         <li>Atmospheric</li>
                         <li>Animated</li>
                     </ul>
-                    <a href="neon-noir.html" class="card__link">View Design &rarr;</a>
+                    <a href="/alternatives/neon-noir.html" class="card__link">View Design &rarr;</a>
                 </div>
             </article>
 
@@ -307,7 +307,7 @@
                 <div class="card__number" aria-hidden="true">06</div>
                 <div>
                     <p class="card__category">Brutalist &mdash; Cyberpunk</p>
-                    <h2 class="card__name"><a href="vhs.html">VHS</a></h2>
+                    <h2 class="card__name"><a href="/alternatives/vhs.html">VHS</a></h2>
                     <p class="card__desc">
                         Worn VHS tape aesthetic. Chromatic aberration, tracking lines, PLAY/REC HUD overlays,
                         live timestamp, glitch bands. VT323 + Chakra Petch. Amber UI on CRT black.
@@ -318,7 +318,7 @@
                         <li>Glitch</li>
                         <li>Animated</li>
                     </ul>
-                    <a href="vhs.html" class="card__link">View Design &rarr;</a>
+                    <a href="/alternatives/vhs.html" class="card__link">View Design &rarr;</a>
                 </div>
             </article>
         </div>


### PR DESCRIPTION
Links used bare relative paths (e.g. brutalist.html) which resolve
incorrectly when the page is accessed without a trailing slash. Changed
all 12 links to use absolute paths (/alternatives/*.html).

https://claude.ai/code/session_01JGBTH1EBuEcodbnEPfcDtJ